### PR TITLE
Fixed issue building image with Python 2.7 dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,23 @@ RUN apt-get update && apt-get install -q -y \
     rm -rf /var/lib/apt/lists/*
 
 # Install Pip n Python modules
-RUN wget https://bootstrap.pypa.io/get-pip.py && \
+RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python get-pip.py && \
-    rm get-pip.py \
-    && pip install python numpy matplotlib ipykernel python-dateutil --upgrade \
-    && python -m ipykernel.kernelspec
+    rm get-pip.py
 
-RUN pip install scipy pandas jupyter
+RUN pip install \
+    pip==20.0.2 \
+    numpy==1.16.6 \
+    matplotlib==2.2.5 \
+    ipykernel==4.10.1 \
+    python-dateutil==2.8.1
+
+ RUN python -m ipykernel.kernelspec
+
+RUN pip install \
+    scipy==1.2.3 \
+    pandas==0.24.2 \
+    jupyter==1.0.0
 
 # Install TensorFlow
 RUN pip --no-cache-dir install \


### PR DESCRIPTION
Fixed issue building image because the Python dependencies are not working more with Python 27 in the last versions.